### PR TITLE
First pass at backlight timer

### DIFF
--- a/src/main/scala/PinWatcher.scala
+++ b/src/main/scala/PinWatcher.scala
@@ -4,6 +4,8 @@ import akka.event.Logging
 import com.pi4j.io.gpio.event.{GpioPinDigitalStateChangeEvent, GpioPinListenerDigital}
 import com.pi4j.io.gpio.{GpioController, GpioPinDigitalInput, Pin, PinPullResistance}
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
 
 
 object PinWatcher {
@@ -24,7 +26,7 @@ class PinWatcher(controller:GpioController, pin:Pin, notify:ActorRef) extends Ac
   protected val input:GpioPinDigitalInput = controller.provisionDigitalInputPin(pin, PinPullResistance.PULL_DOWN)
 
   // Once a minute, poll the actual pin state.  I've seen some glitches and this should reset them.
-  this.context.system.scheduler.schedule(1 minute, 1 minute, self, Poll)
+  context.system.scheduler.schedule(1 minute, 1 minute, self, Poll)
 
   override def receive: Receive = {
     case Watch => input.addListener(this); notify ! PinWatcher.PinNotify(input.getState.isHigh, self)


### PR DESCRIPTION
The motion detector now notifies MCP on every motion.  This resets a 300s timer and turns on the backlight on the LCD display.  The timer decrements every update (1s) and turns off the backlight when the timer reaches zero.